### PR TITLE
Translate comments in Rust client

### DIFF
--- a/client/rust/Cargo.toml
+++ b/client/rust/Cargo.toml
@@ -18,16 +18,16 @@ reqwest      = { version = "0.12", default-features = false, features = ["json",
 thiserror    = "1"
 hostname     = "0"
 
-# 可选
+# Optional
 indicatif    = { version = "0.17", optional = true }
 tracing      = { version = "0.1", features = ["log"], optional = true }
 
 [features]
 default = ["blocking"]
-blocking = []              # 显式列出，避免误开 async
-progress = ["indicatif"]   # 开关式进度条
+blocking = []              # explicitly list to avoid accidentally enabling async
+progress = ["indicatif"]   # switchable progress bar
 log = ["tracing"]
-#async = ["reqwest/async", "tokio", "tracing"]   # 若未来需要
+#async = ["reqwest/async", "tokio", "tracing"]   # if needed in the future
 
 [dev-dependencies]
 #tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }

--- a/client/rust/src/client.rs
+++ b/client/rust/src/client.rs
@@ -21,9 +21,9 @@ impl MitaClient {
     pub fn new(
         url: Option<impl Into<String>>,
         password: Option<impl Into<String>>,
-        threads: Option<usize>,   // 默认为 1
-        queue_cap: Option<usize>, // 默认为 256
-        verbose: bool,            // 和 Python 一致：默认 false
+        threads: Option<usize>,   // default is 1
+        queue_cap: Option<usize>, // default is 256
+        verbose: bool,            // same as Python: default false
     ) -> Result<Self, MitaError> {
         // ---------- 1. Parse URL / PASSWORD ----------
         let url = url

--- a/client/rust/src/components/mod.rs
+++ b/client/rust/src/components/mod.rs
@@ -4,5 +4,5 @@ pub(crate) mod logger;
 pub(crate) mod progress_bar;
 pub(crate) mod variable;
 
-// 若需要“枚举封装”
+// Use this when an enum wrapper is needed
 pub(crate) use common::Component;

--- a/client/rust/src/view.rs
+++ b/client/rust/src/view.rs
@@ -1,5 +1,5 @@
 use crate::components::Component;
-use serde::Serialize; // 假设已在 Cargo.toml 启用 serde + derive
+use serde::Serialize; // assumes serde + derive is enabled in Cargo.toml
 use std::iter::IntoIterator;
 
 #[derive(Serialize)]
@@ -19,7 +19,7 @@ impl View {
         }
     }
 
-    /// 把若干组件批量压入并返回可链式调用的 &mut Self
+    /// Push several components at once and return a chainable &mut Self
     pub fn add<I>(&mut self, components: I) -> &mut Self
     where
         I: IntoIterator<Item = Component>,
@@ -28,11 +28,11 @@ impl View {
         self
     }
 
-    /// 序列化成等价的 Python dict 结构
+    /// Serialize to the equivalent Python dict structure
     pub fn to_json(&self) -> serde_json::Value {
         serde_json::json!({
             "view": self.view,
-            "data": self.data,   // 组件本身已实现 Serialize
+            "data": self.data,   // each component already implements Serialize
         })
     }
 

--- a/client/rust/src/worker.rs
+++ b/client/rust/src/worker.rs
@@ -71,7 +71,7 @@ impl MitaWorker {
         }
     }
 
-    /* ---------- 内部 ---------- */
+    /* ---------- Internal ---------- */
 
     fn spawn_one(
         rx: Receiver<Payload>,


### PR DESCRIPTION
## Summary
- translate non-English comments in the Rust client to English

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684106bbb93c8322996286f63394c33e