### PR TITLE
Add Rust CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run \
 
 The client is the interface to post data to the server.
 
-Now the python client is available. The other clients (nodejs, java, cli, ...) are in plan.
+A Python client and a Rust CLI are included in this repository.
 
 #### Python Client
 
@@ -106,9 +106,33 @@ with Mita(ADDRESS, PASSWORD) as client:
         client.push()
 ```
 
+#### Rust CLI
+
+Build the Rust CLI from source:
+
+```bash
+cargo build --manifest-path client/rust/Cargo.toml --release
+```
+
+Authenticate with a Mita server:
+
+```bash
+mita auth --url http://your.mita.server:9000 --password <PASSWORD>
+```
+
+Tokens are stored in `~/.mita.json` per server URL.
+
+Push updates (falls back to `MITA_ADDRESS` and `MITA_PASSWORD` when flags are omitted):
+
+```bash
+mita push progress_bar progress 20 --total 100
+mita push --view my_view variable some_var "Hello World"
+```
+
 ## License
 
 | Module | License                        |
 |--------|--------------------------------|
 | server | [AGPL](./LICENSE)              |
-| client | [MIT](./client/python/LICENSE) |
+| python client | [MIT](./client/python/LICENSE) |
+| rust client | [MIT](./client/rust/LICENSE) |

--- a/client/rust/Cargo.toml
+++ b/client/rust/Cargo.toml
@@ -17,6 +17,8 @@ serde_json   = "1"
 reqwest      = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 thiserror    = "1"
 hostname     = "0"
+clap         = { version = "4", features = ["derive"] }
+dirs         = "5"
 
 # Optional
 indicatif    = { version = "0.17", optional = true }

--- a/client/rust/src/lib.rs
+++ b/client/rust/src/lib.rs
@@ -1,4 +1,4 @@
-mod api;
+pub mod api;
 mod client;
 mod components;
 mod error;
@@ -21,3 +21,6 @@ pub const MITA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(feature = "progress")]
 pub use mita_tqdm::MitaTqdm;
+
+pub use api::{Api, State};
+pub use error::MitaError;


### PR DESCRIPTION
## Summary
- add Clap & dirs dependencies for CLI
- expose API and error to crates using `pub`
- extend API to return tokens and manage global token
- implement CLI with `auth` and `push` commands
- simplify CLI examples in README

## Testing
- `cargo test --manifest-path client/rust/Cargo.toml`
- `cargo build --manifest-path client/rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68410e2ee7c083229c08b413d096f96a