### PR TITLE
[Rust CLI] Local testing for Rust CLI, and fixed several small issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ mita push progress_bar progress 20 --total 100
 mita push --view my_view variable some_var "Hello World"
 ```
 
+#### Simple CLI demo
+
+```zsh
+#!/bin/bash
+
+MITA_CLI="./target/release/mita"  # the default cargo build directory, or anywhere you put the executable
+VIEW_NAME="cli-test"
+COMP_NAME="progress-loop"
+TOTAL=100
+URL= # your mita server address
+PASSWORD= # your password
+
+# auth on first run
+$MITA_CLI auth --url $URL --password $PASSWORD
+
+# loop
+for ((i=0; i<=$TOTAL; i+=5)); do
+    echo "Push $i/$TOTAL"
+    $MITA_CLI push --view $VIEW_NAME progress_bar "$COMP_NAME" "$i" --total $TOTAL
+    sleep 1
+done
+```
+
 ## License
 
 | Module | License                        |

--- a/client/rust/src/main.rs
+++ b/client/rust/src/main.rs
@@ -79,7 +79,11 @@ fn main() {
 
 fn resolve_url(arg: Option<String>) -> String {
     arg.or_else(|| std::env::var("MITA_ADDRESS").ok())
-        .expect("MITA_ADDRESS not set")
+        .or_else(|| {
+            let tokens = load_tokens();
+            tokens.get("url").cloned()
+        })
+        .expect("MITA_ADDRESS not set (no CLI arg, no env, no auth token)")
 }
 
 fn resolve_pwd(arg: Option<String>) -> String {
@@ -94,7 +98,7 @@ fn cmd_auth(opts: AuthOpts) {
     match api.auth_token(&password) {
         Ok(tok) => {
             let mut tokens = load_tokens();
-            tokens.insert(url, tok);
+            tokens.insert("url".into(), url.clone());
             save_tokens(&tokens);
             println!("Auth success");
         }


### PR DESCRIPTION
Tested the local build with several simple use cases, for example:

```
cargo build --release
./target/release/mita auth --url URL --password PASSWORD ./target/release/mita push progress_bar 12.5
```

Fixed several small issues:

- Previously, when pushing a component, mita will not try to find the authenticated session,
- When retrieving `url` and `token`, it was supposed to have a config json of shape `{ url: <url>, token: <token> }` which was inconsistent with the json creating logic `{ <url>: <token> }`
- Now the structure of json file is:
  ```json
  {
    "last_url": <url>,
    "tokens": {
      <url1>: <token1>,
      <url2>: <token2>,
      ...
    }
  }
  ```
- Previously, we used string to match the component types, now they are replaced by enums.

An additional section was added to README for a demo of running mita executable from terminal.