### PR TITLE
[Rust CLI] Auth via stored JWT token or "forced auth", and added emojis to highlight actions, as well as HTTP indicators

### DIFF
--- a/client/rust/Cargo.toml
+++ b/client/rust/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/ControlNet/mita"
 
 [dependencies]
 crossbeam-channel = "0.5"
+base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"]}
 serde        = { version = "1", features = ["derive"] }
 serde_json   = "1"
 reqwest      = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/client/rust/src/api.rs
+++ b/client/rust/src/api.rs
@@ -1,5 +1,5 @@
 use crate::error::MitaError;
-use crate::MITA_VERSION;
+use crate::{MAX_WAITING_SEC, MITA_VERSION};
 use reqwest::blocking::Client;
 use serde_json::json;
 use std::cell::RefCell;
@@ -25,7 +25,7 @@ impl Api {
         Self {
             url_base: url_base.into(),
             http: Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
+                .timeout(std::time::Duration::from_secs(MAX_WAITING_SEC))
                 .user_agent(format!("mita_client_rust/{}", MITA_VERSION))
                 .build()
                 .unwrap(),

--- a/client/rust/src/api.rs
+++ b/client/rust/src/api.rs
@@ -40,8 +40,7 @@ impl Api {
             .send()?;
 
         if resp.status().is_success() {
-            let tok = resp
-                .json::<serde_json::Value>()?["token"]
+            let tok = resp.json::<serde_json::Value>()?["token"]
                 .as_str()
                 .ok_or(MitaError::Auth)?
                 .to_owned();

--- a/client/rust/src/jwt.rs
+++ b/client/rust/src/jwt.rs
@@ -1,0 +1,26 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct JwtClaims {
+    pub iss: Option<String>,
+    pub exp: Option<i64>,
+    iat: Option<i64>,
+    sub: Option<String>,
+    jti: Option<String>,
+}
+
+impl JwtClaims {
+    pub fn get_expire_datetime(&self) -> Option<DateTime<Utc>> {
+        self.exp
+            .and_then(|ts| DateTime::<Utc>::from_timestamp(ts, 0))
+    }
+}
+
+pub fn parse_jwt_claims(token: &str) -> Option<JwtClaims> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+

--- a/client/rust/src/jwt.rs
+++ b/client/rust/src/jwt.rs
@@ -23,4 +23,3 @@ pub fn parse_jwt_claims(token: &str) -> Option<JwtClaims> {
     let decoded = URL_SAFE_NO_PAD.decode(payload).ok()?;
     serde_json::from_slice(&decoded).ok()
 }
-

--- a/client/rust/src/jwt.rs
+++ b/client/rust/src/jwt.rs
@@ -16,6 +16,12 @@ impl JwtClaims {
         self.exp
             .and_then(|ts| DateTime::<Utc>::from_timestamp(ts, 0))
     }
+
+    pub fn is_token_expired(&self) -> bool {
+        self.get_expire_datetime()
+            .map(|dt| dt < Utc::now())
+            .unwrap_or(true)
+    }
 }
 
 pub fn parse_jwt_claims(token: &str) -> Option<JwtClaims> {

--- a/client/rust/src/lib.rs
+++ b/client/rust/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod api;
-pub mod jwt;
 mod client;
 mod components;
 mod error;
+pub mod jwt;
 #[cfg(feature = "progress")]
 mod mita_tqdm;
 mod view;

--- a/client/rust/src/lib.rs
+++ b/client/rust/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod jwt;
 mod client;
 mod components;
 mod error;

--- a/client/rust/src/lib.rs
+++ b/client/rust/src/lib.rs
@@ -5,6 +5,8 @@ mod error;
 pub mod jwt;
 #[cfg(feature = "progress")]
 mod mita_tqdm;
+pub mod spinner_utils;
+pub mod token_store;
 mod view;
 mod worker;
 
@@ -19,6 +21,8 @@ pub use view::View;
 
 /// similar to __version__ inside setup.py —— written to code
 pub const MITA_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub const MAX_WAITING_SEC: u64 = 30;
 
 #[cfg(feature = "progress")]
 pub use mita_tqdm::MitaTqdm;

--- a/client/rust/src/main.rs
+++ b/client/rust/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
 
 fn resolve_url(arg: Option<String>) -> String {
     arg.or_else(|| std::env::var("MITA_ADDRESS").ok())
-        .or_else(|| { load_token_store().last_url })
+        .or_else(|| load_token_store().last_url)
         .expect("MITA_ADDRESS not set (no CLI arg, no env, no auth token)")
 }
 
@@ -129,7 +129,10 @@ fn print_token_info(url: String, tok: &str) {
     println!("🔐 Already authenticated to: {url}, using auth token of last connection ...");
 
     if let Some(exp_time) = claims.get_expire_datetime() {
-        println!("📅 Token valid through: {}", exp_time.format("%Y-%m-%d %H:%M:%S"));
+        println!(
+            "📅 Token valid through: {}",
+            exp_time.format("%Y-%m-%d %H:%M:%S")
+        );
         if exp_time < Utc::now() {
             println!("❌ Token is expired now.");
             println!("💡 Please execute: mita auth --force");
@@ -229,7 +232,10 @@ fn cmd_push(opts: PushOpts) {
             return;
         }
         Err(MitaError::Auth) => {
-            if let Some(pwd) = opts.password.or_else(|| std::env::var("MITA_PASSWORD").ok()) {
+            if let Some(pwd) = opts
+                .password
+                .or_else(|| std::env::var("MITA_PASSWORD").ok())
+            {
                 match api.auth_token(&pwd) {
                     Ok(tok) => {
                         let mut token_store = load_token_store();

--- a/client/rust/src/main.rs
+++ b/client/rust/src/main.rs
@@ -67,7 +67,7 @@ fn token_file() -> PathBuf {
     let base = match dirs::home_dir() {
         Some(dir) => dir,
         None => {
-            eprintln!("Home directory not found, using current directory for token file");
+            eprintln!("[Mita] Home directory not found, using current directory for token file");
             PathBuf::from(".")
         }
     };
@@ -88,11 +88,11 @@ fn save_token_store(store: &TokenStore) {
     match serde_json::to_string_pretty(store) {
         Ok(json) => {
             if let Err(e) = fs::write(&path, json) {
-                eprintln!("Failed to write token file: {e}");
+                eprintln!("[Mita] Failed to write token file: {e}");
             }
         }
         Err(e) => {
-            eprintln!("Failed to serialize token store: {e}");
+            eprintln!("[Mita] Failed to serialize token store: {e}");
         }
     }
 }
@@ -122,25 +122,25 @@ fn resolve_token(url: &str) -> Option<String> {
 
 fn print_token_info(url: String, tok: &str) {
     let Some(claims) = parse_jwt_claims(tok) else {
-        println!("Error: cannot read JWT claims");
+        eprintln!("[Mita/Auth] Error: cannot read JWT claims");
         return;
     };
 
-    println!("Already authenticated to: {url}, using auth token of last connection ...");
+    println!("🔐 Already authenticated to: {url}, using auth token of last connection ...");
 
     if let Some(exp_time) = claims.get_expire_datetime() {
-        println!("Token valid through: {}", exp_time.format("%Y-%m-%d %H:%M:%S"));
+        println!("📅 Token valid through: {}", exp_time.format("%Y-%m-%d %H:%M:%S"));
         if exp_time < Utc::now() {
-            println!("Token is expired now.");
-            println!("Please execute: mita auth --force");
+            println!("❌ Token is expired now.");
+            println!("💡 Please execute: mita auth --force");
             return;
         }
     } else {
-        println!("No expire date found");
+        println!("⚠️ No expire date found.");
     }
 
     if let Some(iss) = &claims.iss {
-        println!("Issuer: {iss}");
+        println!("🔖 Issuer: {iss}.");
     }
 
     return;
@@ -160,7 +160,7 @@ fn cmd_auth(opts: AuthOpts) {
         }
     }
 
-    println!("Authenticating to server: {url}");
+    println!("🔄 Authenticating to server: {url}");
 
     let password = resolve_pwd(opts.password);
     let api = Api::new(&url);
@@ -169,10 +169,10 @@ fn cmd_auth(opts: AuthOpts) {
             store.last_url = Some(url.clone());
             store.tokens.insert(url.clone(), tok.clone());
             save_token_store(&store);
-            println!("Auth success to server: {url}");
+            println!("✅ Auth success to server: {url}");
         }
         Err(e) => {
-            eprintln!("Auth failed: {e}");
+            eprintln!("[Mita/Auth] Auth failed: {e}");
             std::process::exit(1);
         }
     }
@@ -225,7 +225,7 @@ fn cmd_push(opts: PushOpts) {
 
     match api.push(&view) {
         Ok(()) => {
-            println!("Push success");
+            println!("📤 Push success.");
             return;
         }
         Err(MitaError::Auth) => {
@@ -237,21 +237,21 @@ fn cmd_push(opts: PushOpts) {
                         token_store.tokens.insert(url.clone(), tok.clone());
                         save_token_store(&token_store);
                         if api.push(&view).is_ok() {
-                            println!("Push success");
+                            println!("📤 Push success.");
                             return;
                         }
                     }
                     Err(e) => {
-                        eprintln!("Auth failed: {e}");
+                        eprintln!("[Mita/Auth] Auth failed: {e}");
                         std::process::exit(1);
                     }
                 }
             }
-            eprintln!("Authentication required");
+            eprintln!("[Mita/Auth] Authentication required");
             std::process::exit(1);
         }
         Err(e) => {
-            eprintln!("Push failed: {e}");
+            eprintln!("[Mita/Error] Push failed: {e}");
             std::process::exit(1);
         }
     }

--- a/client/rust/src/main.rs
+++ b/client/rust/src/main.rs
@@ -99,7 +99,6 @@ fn print_token_info(url: &String, claims: &JwtClaims) {
         println!("🔖 Issuer: {iss}.");
     }
 
-    return;
 }
 
 fn cmd_auth(opts: AuthOpts) {

--- a/client/rust/src/main.rs
+++ b/client/rust/src/main.rs
@@ -156,14 +156,21 @@ fn cmd_auth(opts: AuthOpts) {
 
     if !opts.force {
         if let Some(tok) = store.tokens.get(&url) {
-            print_token_info(url, tok);
+            let Some(claims) = parse_jwt_claims(tok) else {
+                eprintln!("[Mita/Auth] Error: cannot read JWT claims");
+                return;
+            };
 
-            // Silently exit the program
-            return;
+            print_token_info(&url, &claims);
+
+            if !claims.is_token_expired() {
+                // Silently exit the program
+                return;
+            }
+
+            println!("⚠️ Token expired, trying to refresh it...");
         }
     }
-
-    println!("🔄 Authenticating to server: {url}");
 
     let password = resolve_pwd(opts.password);
     let api = Api::new(&url);

--- a/client/rust/src/spinner_utils.rs
+++ b/client/rust/src/spinner_utils.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+pub fn with_spinner<T, F: FnOnce() -> T>(msg: &str, f: F) -> T {
+    #[cfg(feature = "progress")]
+    {
+        use indicatif;
+        let spinner = indicatif::ProgressBar::new_spinner();
+        spinner.set_style(
+            indicatif::ProgressStyle::with_template("{spinner} {msg}")
+                .unwrap()
+                .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+        );
+        spinner.set_message(msg.to_string());
+        spinner.enable_steady_tick(Duration::from_micros(100));
+
+        let result = f();
+        spinner.finish_and_clear();
+        result
+    }
+
+    #[cfg(not(feature = "progress"))]
+    {
+        use crate::MAX_WAITING_SEC;
+        println!("{msg} (max wait ~{MAX_WAITING_SEC}s)");
+        f()
+    }
+}

--- a/client/rust/src/spinner_utils.rs
+++ b/client/rust/src/spinner_utils.rs
@@ -11,7 +11,7 @@ pub fn with_spinner<T, F: FnOnce() -> T>(msg: &str, f: F) -> T {
                 .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
         );
         spinner.set_message(msg.to_string());
-        spinner.enable_steady_tick(Duration::from_micros(100));
+        spinner.enable_steady_tick(Duration::from_millis(100));
 
         let result = f();
         spinner.finish_and_clear();

--- a/client/rust/src/token_store.rs
+++ b/client/rust/src/token_store.rs
@@ -30,7 +30,13 @@ fn token_file() -> PathBuf {
 pub fn load_token_store() -> TokenStore {
     let path = token_file();
     if let Ok(s) = fs::read_to_string(path) {
-        serde_json::from_str(&s).unwrap_or_default()
+        match serde_json::from_str(&s) {
+            Ok(store) => store,
+            Err(e) => {
+                eprintln!("[Mita] Failed to deserialize token file: {e}");
+                TokenStore::default()
+            }
+        }
     } else {
         TokenStore::default()
     }

--- a/client/rust/src/token_store.rs
+++ b/client/rust/src/token_store.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct TokenStore {
+    pub last_url: Option<String>,
+    pub tokens: HashMap<String, String>,
+}
+
+impl TokenStore {
+    pub fn insert_new_token(&mut self, url: &str, token: String) {
+        self.tokens.insert(url.to_string(), token);
+        self.last_url = Some(url.to_string());
+    }
+}
+
+fn token_file() -> PathBuf {
+    let base = match dirs::home_dir() {
+        Some(dir) => dir,
+        None => {
+            eprintln!("[Mita] Home directory not found, using current directory for token file");
+            PathBuf::from(".")
+        }
+    };
+    base.join(".mita.json")
+}
+
+pub fn load_token_store() -> TokenStore {
+    let path = token_file();
+    if let Ok(s) = fs::read_to_string(path) {
+        serde_json::from_str(&s).unwrap_or_default()
+    } else {
+        TokenStore::default()
+    }
+}
+
+pub fn save_token_store(store: &TokenStore) {
+    let path = token_file();
+    match serde_json::to_string_pretty(store) {
+        Ok(json) => {
+            if let Err(e) = fs::write(&path, json) {
+                eprintln!("[Mita] Failed to write token file: {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("[Mita] Failed to serialize token store: {e}");
+        }
+    }
+}

--- a/client/rust/src/worker.rs
+++ b/client/rust/src/worker.rs
@@ -96,10 +96,7 @@ impl MitaWorker {
                 match api.push(&payload) {
                     Ok(()) => {
                         if verbose {
-                            println!(
-                                "[MitaWorker] pushed in {:.3}s",
-                                t0.elapsed().as_secs_f64()
-                            );
+                            println!("[MitaWorker] pushed in {:.3}s", t0.elapsed().as_secs_f64());
                         }
                     }
                     Err(MitaError::Auth) => {


### PR DESCRIPTION
Updated the auth process to first check the existing of a jwt token. If the token is present, we will try to login via this token.

The user can always force the login and request a new token via `--force` parameter.

In case of reuse of existing token, we will prompt the expire date and issuer of this jwt claims, and attempt to renew it in case of expiration.

Also added a spinner indicator for auth and push actions. This requires the indicatif dependency (hence the `progress` compilation param). In other case, we will fallback to a simple printout of timeout to tell the user the max attempt timeout.