### PR TITLE
[CI/Rust] Fix clippy CI issues + rework on thread spawning (usage of `stop` flag)

### DIFF
--- a/client/rust/src/jwt.rs
+++ b/client/rust/src/jwt.rs
@@ -6,9 +6,6 @@ use serde::Deserialize;
 pub struct JwtClaims {
     pub iss: Option<String>,
     pub exp: Option<i64>,
-    iat: Option<i64>,
-    sub: Option<String>,
-    jti: Option<String>,
 }
 
 impl JwtClaims {

--- a/client/rust/src/main.rs
+++ b/client/rust/src/main.rs
@@ -194,7 +194,6 @@ fn cmd_push(opts: PushOpts) {
     match push_result {
         Ok(()) => {
             println!("📤 Push success.");
-            return;
         }
         Err(MitaError::Auth) => {
             if let Some(pwd) = opts

--- a/client/rust/src/spinner_utils.rs
+++ b/client/rust/src/spinner_utils.rs
@@ -1,9 +1,9 @@
-use std::time::Duration;
-
 pub fn with_spinner<T, F: FnOnce() -> T>(msg: &str, f: F) -> T {
     #[cfg(feature = "progress")]
     {
+        use std::time::Duration;
         use indicatif;
+
         let spinner = indicatif::ProgressBar::new_spinner();
         spinner.set_style(
             indicatif::ProgressStyle::with_template("{spinner} {msg}")


### PR DESCRIPTION
- Moved import statement into conditional compilation blocks,
- Removed unused return statement,
- Removed unused fields in jwt structure,
- Reworked the main loop of spawn_one() to take care the stop flag.